### PR TITLE
overwrite default default-testCompile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,12 +84,9 @@
                             </compilerArgs>
                         </configuration>
                     </execution>
+
                     <execution>
-                        <id>compile-tests</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
+                        <id>default-testCompile</id>
                         <configuration>
                             <release>25</release>
                         </configuration>


### PR DESCRIPTION
fixes:

```
[WARNING] bootstrap class path is not set in conjunction with -source 8
  not setting the bootstrap class path may lead to class files that cannot run on JDK 8
    --release 8 is recommended instead of -source 8 -target 1.8 because it sets the bootstrap class path automatically
[WARNING] source value 8 is obsolete and will be removed in a future release
[WARNING] target value 8 is obsolete and will be removed in a future release
[WARNING] To suppress warnings about obsolete options, use -Xlint:-options.
```